### PR TITLE
Add external airline logo from data with backup

### DIFF
--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -48,7 +48,7 @@ describe("DatesPicker: Formik integration", () => {
             }
         };
 
-        render(
+        const { container }  = render(
             <DatesPicker
                 display
                 fieldName="TestPicker"
@@ -57,7 +57,7 @@ describe("DatesPicker: Formik integration", () => {
                 formik={formik}
             />
         )
-        let pickerTextNode = screen.getByLabelText('TestPicker');
+        let pickerTextNode = container.querySelector("input[name='TestPicker']") as Element;
         userEvent.type(pickerTextNode, "08/01/2022{enter}");
         expect(setFieldValue.calledOnceWith("TestPicker")).toBeTruthy();
     });

--- a/src/components/FlightCard/FlightCard.module.css
+++ b/src/components/FlightCard/FlightCard.module.css
@@ -29,3 +29,9 @@
 .amountButton {
     font-weight: bold;
 }
+
+.airlineLogo {
+    width: 90%;
+    max-width: 160px;
+    max-height: 50px;
+}

--- a/src/components/FlightCard/FlightInfoComponent.tsx
+++ b/src/components/FlightCard/FlightInfoComponent.tsx
@@ -3,14 +3,22 @@ import { Typography, Box, LinearProgress, Grid } from "@mui/material";
 import { convertDate, timeTravelDiff } from "../../utils/utils"
 import flightCardStyles from "./FlightCard.module.css"
 
-const aaImgUrlDummy = "https://www.aa.com/content/images/homepage/mobile-hero/en_US/Airplane-1.png"
+const airlineFailoverLogo = "https://upload.wikimedia.org/wikipedia/commons/2/23/Flugzeug_mit_Nase_nach_oben.svg";
 
 const FlightInfoComponent: React.FC<{itineraries: ItinerariesProps}> = ({itineraries}: {itineraries: ItinerariesProps}) => {
-    const {departure, arrival} = itineraries
+    const {departure, arrival, carrierCode} = itineraries;
+    const svgLogo = `https://airlinecodes.info/airlinelogos/${carrierCode}.svg`;
     return (
         <Grid item xs={12} container data-testid="flightInfoComponent">
             <Grid item xs={2} container justifyContent="center" alignItems="center">
-                <img alt="airlineIcon" src={aaImgUrlDummy} width={40}/>
+                <img 
+                    alt="airlineIcon" 
+                    src={svgLogo}
+                    onError={(evt: React.SyntheticEvent<HTMLImageElement, Event>) => {
+                        evt.currentTarget.src = airlineFailoverLogo
+                    }}
+                    className={flightCardStyles.airlineLogo}
+                />
             </Grid>
             <Grid item xs={10} container className={flightCardStyles.originDestiny}>
                 <Grid item xs={12} container justifyContent="space-between">


### PR DESCRIPTION
Extracts IATA code from flight offer data, then it tries to get the logo in svg from airlinecodes.info, if the logo is not listed, then i it defaults to a simple airplane icon. 
I also fixed a broken test.

Example with listed airlines:
![Screen Shot 2022-08-10 at 16 31 47](https://user-images.githubusercontent.com/109627351/184024131-7d82c566-a3ab-4986-82c6-e8230864d4f1.png)

Example with non-listed airline:
![Screen Shot 2022-08-10 at 16 33 22](https://user-images.githubusercontent.com/109627351/184024312-5cf1001f-e80f-4bc3-83e8-fc67209f7baa.png)
