### PR TITLE
Fs 74 unable to update destination and departure

### DIFF
--- a/src/components/AirportPicker/AiportPicker.test.tsx
+++ b/src/components/AirportPicker/AiportPicker.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import AirportPicker from "./AirportPicker";
 import userEvent from "@testing-library/user-event";
 
+const airportsOptions = [{name: "", label: ""}]
+
 describe("AiportPicker component", () => {
   afterEach(() => {
     jest.clearAllMocks()
@@ -15,6 +17,8 @@ describe("AiportPicker component", () => {
         }}
         fieldName="airport-picker-test"
         handleDataName={() => {}}
+        airportsOptions={airportsOptions}
+        handleFlightChange={() => {}}
       />
     );
     expect(screen.getByTestId("airport-picker-test")).toBeInTheDocument();
@@ -33,6 +37,9 @@ describe("Airport Component: Formik integration", () => {
 
     render(
       <AirportPicker
+        airportsOptions={airportsOptions}
+        handleFlightChange={() => {}}
+
         flightType="departure"
         formik={formik}
         fieldName="airport-picker-test"
@@ -59,6 +66,8 @@ describe("Airport Component: Formik integration", () => {
 
     render(
         <AirportPicker
+            airportsOptions={airportsOptions}
+            handleFlightChange={() => {}}
             flightType="departure"
             formik={formik}
             fieldName="airport-picker-test"
@@ -85,6 +94,8 @@ describe("Airport Component: Formik integration", () => {
 
     render(
         <AirportPicker
+            airportsOptions={airportsOptions}
+            handleFlightChange={() => {}}
             flightType="departure"
             formik={formik}
             fieldName="airport-picker-test"
@@ -104,6 +115,8 @@ describe("Airport Component: Formik integration", () => {
 
     render(
         <AirportPicker
+            airportsOptions={airportsOptions}
+            handleFlightChange={() => {}}
             flightType="departure"
             formik={formik}
             fieldName="airport-picker-test"

--- a/src/components/AirportPicker/AirportPicker.tsx
+++ b/src/components/AirportPicker/AirportPicker.tsx
@@ -1,10 +1,11 @@
 import {Alert, Autocomplete, FormControl, TextField, Grid } from "@mui/material";
 import { Place, AirplanemodeActive } from "@mui/icons-material";
-import React, { useEffect, useState} from "react";
-import { getData } from "./getData"
-import axios from "axios";
 import styles from "../../pages/HomePage/HomePage.module.css"
-import {Airport} from "../../intefaces/flights";
+
+interface options {
+  name: string;
+  label: string;
+}
 
 interface AirportPickerProps {
   flightType: string;
@@ -12,6 +13,8 @@ interface AirportPickerProps {
   fieldName: string;
   handleDataName: Function
   compact?: boolean;
+  airportsOptions: options[];
+  handleFlightChange: Function;
 }
 
 interface IconComponentProps {
@@ -23,30 +26,10 @@ const AirportPicker: React.FC<AirportPickerProps> = ({
   flightType,
   fieldName,
   handleDataName,
-  compact
+  compact,
+  airportsOptions,
+  handleFlightChange
 }: AirportPickerProps) => {
-  const handleFlightChange = (flightInfo: string) => {
-    const { out } = getData({keyword: flightInfo});
-    const lowerCase = flightInfo.toLowerCase()
-
-    if(lowerCase === "lax" ){
-      formik.setFieldValue(fieldName, "LOS ANGELES, CA, LOS ANGELES INTL")
-      handleDataName({name: "LAX", type: fieldName})
-    } else {
-      formik.setFieldValue(fieldName, flightInfo)
-    }
-
-    if (compact) {
-      formik.setFieldValue(fieldName, formik.getFieldProps(fieldName).value)
-    }
-
-    out.then(res => {
-      setAirportsOptions(res.data);
-    }).catch(err => {
-      axios.isCancel(err);
-    });
-  };
-
   const IconComponent: React.FC<IconComponentProps> = ({ type }) => {
     switch (type) {
       case "departure":
@@ -66,18 +49,10 @@ const AirportPicker: React.FC<AirportPickerProps> = ({
     }
   };
 
-  const [airportsOptions, setAirportsOptions] = useState([{name: "Loading ...", label: "Loading ..."}]);
-  const [isDisabled, setIsDisabled] = useState(false)
-
-  useEffect(() => {
-    handleFlightChange(formik.initialValues[fieldName])
-  }, []);
-
   const handleAutocomplete = (info: HTMLElement) => {
     const nameCode = airportsOptions.filter((item) => item.label === info.innerText)
     formik.setFieldValue(fieldName, nameCode[0].label)
     handleDataName({name: nameCode[0].name, type: fieldName})
-    setIsDisabled(true)
   }
 
   return (
@@ -95,7 +70,6 @@ const AirportPicker: React.FC<AirportPickerProps> = ({
             disablePortal
             id="autocompleteSearch"
             data-testid="autocompleteSearch"
-            disabled={isDisabled}
             options={airportsOptions}
             onChange={(e: any) => handleAutocomplete(e.target)}
             value={formik.getFieldProps(fieldName).value}
@@ -104,7 +78,7 @@ const AirportPicker: React.FC<AirportPickerProps> = ({
                 <TextField
                 {...params}
                 label={selectLabel(flightType)}
-                onChange={(e: any) => handleFlightChange(e.target.value)}
+                onChange={(e: any) => handleFlightChange(e.target.value,fieldName, compact)}
                 onBlur={formik.getFieldProps(fieldName).onBlur}
                 value={formik.getFieldProps(fieldName).value}
                 name={formik.getFieldProps(fieldName).name}

--- a/src/components/CompactSearchForm/CompactSearchForm.tsx
+++ b/src/components/CompactSearchForm/CompactSearchForm.tsx
@@ -7,6 +7,11 @@ import {IFlightSearchStatus} from "../../pages/HomePage/interfaces";
 import {FormState} from "../../utils/FormReducer";
 import constants from "../../utils/constants";
 
+interface options {
+    name: string;
+    label: string;
+  }
+
 interface Props {
     formik: any
     departureDispatcher: Function;
@@ -15,9 +20,22 @@ interface Props {
     dateArrivalDispatcher: Function;
     formState: FormState
     handleDataName: Function;
+    airportsOptions: options[];
+    handleFlightChange: Function;
 }
 
-export const CompactSearchForm = ({ formik, departureDispatcher, arrivalDispatcher, formState, dateDepartureDispatcher, dateArrivalDispatcher, handleDataName }: Props) => {
+export const CompactSearchForm = (
+    { 
+        formik, 
+        departureDispatcher, 
+        arrivalDispatcher, 
+        formState, 
+        dateDepartureDispatcher, 
+        dateArrivalDispatcher, 
+        handleDataName, 
+        airportsOptions,
+        handleFlightChange,
+    }: Props) => {
     const [flightSearchStatus, setFlightSearchStatus] = useState<IFlightSearchStatus>({isLoading: false});
 
     return (
@@ -30,6 +48,8 @@ export const CompactSearchForm = ({ formik, departureDispatcher, arrivalDispatch
                         formik={formik}
                         fieldName="departureFlight"
                         compact
+                        airportsOptions={airportsOptions}
+                        handleFlightChange={handleFlightChange}
                     />
 
                 </Grid>
@@ -40,6 +60,8 @@ export const CompactSearchForm = ({ formik, departureDispatcher, arrivalDispatch
                         formik={formik}
                         fieldName="destinationFlight"
                         compact
+                        airportsOptions={airportsOptions}
+                        handleFlightChange={handleFlightChange}
                     />
                 </Grid>
                 <Grid item xs={12}>


### PR DESCRIPTION
# Description :alien:
Unable to update Origin and Destination Airports before edit

## Issue ticket :memo:
[Unable to update Origin and Destination Airports](https://skywalkersdxc.atlassian.net/browse/FS-74)

## Images
<details>
<summary>Mobile Version :iphone: :point_left: </summary>
<br>
<img width="385" alt="Screen Shot 2022-08-29 at 11 44 28" src="https://user-images.githubusercontent.com/109685831/187252052-26fe1ea4-02b2-4dc5-9043-99025de896ff.png">
<img width="380" alt="Screen Shot 2022-08-29 at 11 45 07" src="https://user-images.githubusercontent.com/109685831/187252071-a79a5f77-a65a-4412-a522-a7a68406cc7f.png">
</details>

## Details
:star: Lift state up from AirportPicker to HomePage
:star: Refactor both components
:star: Add necessary props to AirportPicker.test and to CompactSearchForm components 
